### PR TITLE
`toLowerCase` a string or an empty one

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -24,7 +24,7 @@
             <%
               var agent = slaves[i], classes = [];
 
-              classes.push(agent.name.toLowerCase());
+              classes.push((agent.name || '').toLowerCase());
               if (/windows/i.test(agent.os.family)) {
                   classes.push("windows");
               } else if (/os x/i.test(agent.os.family)) {


### PR DESCRIPTION
agent.name could somehow be `null` and will cause `buster-server-cli` to exit.

The solution is to make sure the agent.name is truthy before invoking `toLowerCase`.